### PR TITLE
ウィンドウサイズを変更した際に描画がおかしくなるバグを修正

### DIFF
--- a/game/game.go
+++ b/game/game.go
@@ -17,6 +17,8 @@ import (
 )
 
 type Game struct {
+	width      int
+	height     int
 	components []ui.Component
 	buttons    []*ui.Button
 	noticer    *ui.Noticer
@@ -91,9 +93,10 @@ func (g *Game) Draw(screen *ebiten.Image) {
 }
 
 func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
-	w, h := ebiten.WindowSize()
-	if w != outsideWidth || h != outsideHeight {
+	if g.width != outsideWidth || g.height != outsideHeight {
 		ebiten.SetWindowSize(outsideWidth, outsideHeight)
+		g.width = outsideWidth
+		g.height = outsideHeight
 		for _, c := range g.components {
 			c.Layout(outsideWidth, outsideHeight)
 		}

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -24,7 +24,6 @@ func NewMenu(children []Component) *Menu {
 }
 
 func (m *Menu) Update() error {
-	_, m.height = ebiten.WindowSize()
 	for _, c := range m.children {
 		c.Update()
 	}
@@ -41,6 +40,7 @@ func (m *Menu) Draw(screen *ebiten.Image) {
 }
 
 func (m *Menu) Layout(outsideWidth, outsideHeight int) {
+	m.height = outsideHeight
 	for _, c := range m.children {
 		c.Layout(outsideWidth, outsideHeight)
 	}


### PR DESCRIPTION
なぜかMacではきちんと動いていたが、Windows機で発生したので対応